### PR TITLE
Fix/aktnk issue#46 fix ogp builder and follow latest tokyometoro

### DIFF
--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -43,22 +43,26 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ steps.extract_branch.outputs.branch }}
-    - name: Download ogp images
-      uses: actions/download-artifact@v1
-      with:
-        name: ogp
-    - name: Commit files
-      run: |
-        cp -rp ogp static/
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add static
-        git commit -m "Add changes"
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ steps.extract_branch.outputs.branch }}
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Download ogp images
+        uses: actions/download-artifact@v1
+        with:
+          name: ogp
+      - name: Commit files
+        run: |
+          cp -rp ogp static/
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add static
+          git commit -m "Add changes"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - staging
 
 jobs:
   build:
@@ -21,11 +20,14 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- https://github.com/aktnk/covid19/issues/46

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/3072
- https://github.com/tokyo-metropolitan-gov/covid19/pull/3357
- https://github.com/tokyo-metropolitan-gov/covid19/pull/4537

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ogp_builderのワークフローが動かなかった問題を修正
- 正しくブランチ名を指定しないとpushがうまく動いてくれません
  - https://github.com/aktnk/covid19/issues/46#issue-752665251
- そのほか
  - actions/cacheのv1をv2に変更しました -> https://github.com/tokyo-metropolitan-gov/covid19/pull/4537
  - ステージングの時にogb_builderを走らせないように外しました。 -> https://github.com/tokyo-metropolitan-gov/covid19/pull/3357
- 現在はメトロ版に追従しています。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
