### PR TITLE
「検査陽性者の状況」の個別ページ表示時のエラーを修正

### DIFF
--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -99,7 +99,7 @@ export default {
     switch (this.$route.params.card) {
       case 'details-of-confirmed-cases':
         title = this.$t('検査陽性者の状況')
-        updatedAt = Data.inspection_persons.date
+        updatedAt = Data.patients.date
         break
       case 'details-of-tested-cases':
         title = this.$t('検査実施状況')


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close aktnk#47

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- _card.vue内に定義された「検査陽性者の状況」の更新日時を、ConfimedCasesDetailsCard.vueと同じ内容に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- エラーなく表示されることを確認した。
![2020-11-29_22-17_1](https://user-images.githubusercontent.com/13390370/100543612-6a020d00-3294-11eb-8022-09b1990fa37a.png)
