### PR TITLE
fix ogp meta. url and twitter account name

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://stopcovid19.metro.tokyo.lg.jp'
+        content: 'https://stopcovid19.code4numazu.org'
       },
       {
         hid: 'twitter:card',
@@ -33,12 +33,12 @@ const config: Configuration = {
       {
         hid: 'twitter:site',
         name: 'twitter:site',
-        content: '@tokyo_bousai'
+        content: '@shizuoka_bousai'
       },
       {
         hid: 'twitter:creator',
         name: 'twitter:creator',
-        content: '@tokyo_bousai'
+        content: '@shizuoka_bousai'
       },
       {
         hid: 'fb:app_id',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- https://github.com/aktnk/covid19/issues/52

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- OGPタグのog:urlを静岡県版の対策サイトURLに変更します
- OGPタグのTwitterアカウントを静岡県防災のアカウント（ https://twitter.com/shizuoka_bousai ）へ切り替えます

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

設定後に`yarn dev`で開発サイトを起動した後のChromeDevToolより

![image](https://user-images.githubusercontent.com/23502/103446939-62d18300-4cc8-11eb-9ea6-9c8e7bf4dfd9.png)
