### PR TITLE
reviewdogのセットアップ時にあらかじめeslintをインストールする

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - name: setup eslint
+        run: npm install --legacy-peer-deps
       - name: eslint review
         uses: reviewdog/action-eslint@v1
         with:


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #https://github.com/aktnk/covid19/issues/69

## 📝 関連する issue / Related Issues
- https://github.com/hiroyuki-ichikawa/fujicity_covid19/issues/35
- https://github.com/hiroyuki-ichikawa/fujicity_covid19/pull/36/

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- reviewdogが動作しない問題（関連issue参照）があるため、問題となるeslintをあらかじめインストールするステップを追加

Thanks🎉 @euledge