### PR TITLE
GitHub Actionsを使ってデータ用のjsonファイル生成と更新を行う(rev2

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -10,7 +10,7 @@ env:
   DEVELOPMENT_BRANCH: development
 jobs:
   data_generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           path: data_dist
   data_upload_development:
     needs: data_generate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -76,7 +76,7 @@ jobs:
           branch: ${{ env.DEVELOPMENT_BRANCH }}
   data_upload_deploy:
     needs: data_generate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -50,7 +50,8 @@ jobs:
     needs: data_generate
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout from ${{ env.DEVELOPMENT_BRANCH }} 
+        uses: actions/checkout@v2
         with:
           ref: ${{ env.DEVELOPMENT_BRANCH }}
           fetch-depth: 0
@@ -79,7 +80,8 @@ jobs:
     needs: data_generate
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout from ${{ env.MAIN_BRANCH }} 
+        uses: actions/checkout@v2
         with:
           ref: ${{ env.MAIN_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout from covid19-gen-datajson-shizuokapref
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         with:
           repository: hrsano645/covid19-gen-datajson-shizuokapref
           ref: master

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -1,0 +1,103 @@
+name: datajson update
+
+on:
+  workflow_dispatch:
+  schedule:
+  # 毎日20時に実行:GitHub ActionsはUTCなので、JST(UTC-9)の11時に実行
+    - cron:  '0 11 * * *'
+env:
+  MAIN_BRANCH: master
+  DEVELOPMENT_BRANCH: development
+jobs:
+  data_generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: hrsano645/covid19-gen-datajson-shizuokapref
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Generate jsonfiles
+        run: |
+          bash bat.sh
+          mkdir data_dist
+          cp *.json data_dist/
+      - name: Upload jsonfiles
+        uses: actions/upload-artifact@v1
+        with:
+          name: datajson
+          path: data_dist
+  data_upload_development:
+    needs: data_generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.DEVELOPMENT_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Download data
+        uses: actions/download-artifact@v1
+        with:
+          name: datajson
+      - name: debug recode datetime
+        run: echo `date` > data/recode_workflow_run_time.txt
+      - name: Commit files
+        run: |
+          cp -rp datajson/* data/
+          rm -rf datajson
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/*
+          git commit -m "Auto Update Data"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DEVELOPMENT_BRANCH }}
+  data_upload_deploy:
+    needs: data_generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.MAIN_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: Download data
+        uses: actions/download-artifact@v1
+        with:
+          name: datajson
+      - name: Commit files
+        run: |
+          cp -rp datajson/* data/
+          rm -rf datajson
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/*
+          git commit -m "Auto Update Data"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.MAIN_BRANCH }}

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -12,6 +12,7 @@ jobs:
   data_generate:
     runs-on: ubuntu-20.04
     steps:
+      - name: checkout from covid19-gen-datajson-shizuokapref
       - uses: actions/checkout@v2
         with:
           repository: hrsano645/covid19-gen-datajson-shizuokapref

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -3,7 +3,7 @@ name: datajson update
 on:
   workflow_dispatch:
   schedule:
-  # 毎日20時に実行:GitHub ActionsはUTCなので、JST(UTC-9)の11時に実行
+  # 毎日20時に実行:GitHub ActionsはUTCなので、日本時間(JSTはUTCの9時間前)の20時->UTCの11時に実行
     - cron:  '0 11 * * *'
 env:
   MAIN_BRANCH: master

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -61,8 +61,6 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: datajson
-      - name: debug recode datetime
-        run: echo `date` > data/recode_workflow_run_time.txt
       - name: Commit files
         run: |
           cp -rp datajson/* data/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows:
+      - "datajson update"
+    branched: [master]
+    types:
+      - completed
+
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,8 @@ on:
   workflow_run:
     workflows:
       - "datajson update"
-    branched: [master]
     types:
       - completed
-
 
 jobs:
   deploy:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,7 +7,6 @@ on:
   workflow_run:
     workflows:
       - "datajson update"
-    branched: [development]
     types:
       - completed
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - development
+  workflow_run:
+    workflows:
+      - "datajson update"
+    branched: [development]
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -7,10 +7,8 @@ on:
   workflow_run:
     workflows:
       - "datajson update"
-    branched: [master]
     types:
       - completed
-
 
 jobs:
   build:

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows:
+      - "datajson update"
+    branched: [master]
+    types:
+      - completed
+
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/aktnk/covid19/issues/54
  - 動作の詳しい説明とテスト結果: https://github.com/aktnk/covid19/issues/54#issuecomment-845699636

## 📝 関連する issue / Related Issues
- #155 : このPRの前バージョンです。

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 普段サーバーで行っている定期更新のスクリプトをGitHub Actions（ワークフロー）で行います
- スケジュール動作として 毎日20時に動作します。なおGitHub ActionsではUTC表記でJSTは-9時間です。（UTC11時に実行されます）
  - 1時間ずらしている理由は、現在動いているサーバー側と同じにすると適切に動かない可能性が考えられるため。
- スケジュール動作以外にもworkflow_dispatchトリガーを入れてあるので手動実行も可能です。
- development, master双方に実行されます。データ生成後に対策サイトの生成（デプロイ）が動作させる変更もしています。workflow_runトリガーで実現してます。
  - .github/workflows/develop.yml: 対策サイトの開発版を生成
  - .github/workflows/deploy.yml: 対策サイトの本番用を生成
  - .github/workflows/ogp_builder.yml: 対策サイトの本番用で使うOGP画像を生成

## 動作確認方法

動作テストをする場合は以下の手順でできます。

- 動作テスト専用のgithubリポジトリ作成
- development, masterそれぞれのブランチをpush
- development側をこのPRのバージョンの変更を加えてcommitします（development直接編集かmergeでもできたはず）
- Actionsの`datajson update`内にある、`Run Workflow`ボタンから実行します。ブランチはdevelopment指定で動かせます。